### PR TITLE
Support Basler camera creation with different types of ID (serial number, user name)

### DIFF
--- a/include/BaslerCamera.h
+++ b/include/BaslerCamera.h
@@ -87,8 +87,8 @@ class LIBBASLER_API Camera
       PatternGenerator1, PatternGenerator2, PatternGenerator3, PatternGenerator4,
       AcquisitionTriggerReady,
     };
-    
-    Camera(const std::string& camera_ip,int packet_size = -1,int received_priority = 0);
+
+    Camera(const std::string& camera_id,int packet_size = -1,int received_priority = 0);
     ~Camera();
 
     void prepareAcq();
@@ -198,7 +198,7 @@ class LIBBASLER_API Camera
     int                         m_socketBufferSize;
     
     //- basler stuff 
-    string                      m_camera_ip;
+    string                      m_camera_id;
     string                      m_detector_model;
     string                      m_detector_type;
     Size                        m_detector_size;


### PR DESCRIPTION
Basler camera can be created with different IDs:
- serial_number (use: sn://<serial number>)
- user_name (use: uname://<user name>)
- ip (or hostname) (use ip://<ip or hostname>). Prefix ip:// is optional