### PR TITLE
Auto reconnection

### DIFF
--- a/sip/BaslerCamera.sip
+++ b/sip/BaslerCamera.sip
@@ -46,8 +46,8 @@ namespace Basler
     void setLatTime(double  lat_time);
     void getLatTime(double& lat_time /Out/);
 
-    void getExposureTimeRange(double& min_expo /Out/, double& max_expo /Out/) const;
-    void getLatTimeRange(double& min_lat /Out/, double& max_lat /Out/) const;
+    void getExposureTimeRange(double& min_expo /Out/, double& max_expo /Out/);
+    void getLatTimeRange(double& min_lat /Out/, double& max_lat /Out/);
 
     void setNbFrames(int  nb_frames);
     void getNbFrames(int& nb_frames /Out/);
@@ -66,17 +66,17 @@ namespace Basler
 
     void setFrameTransmissionDelay(int ftd);
 
-    void getFrameRate(double& frame_rate /Out/) const;
-    bool isBinningAvailable() const;
-    bool isRoiAvailable() const;
+    void getFrameRate(double& frame_rate /Out/);
+    bool isBinningAvailable();
+    bool isRoiAvailable();
     void setTimeout(int TO);
     void reset();
 
     void setAutoGain(bool auto_gain);
-    void getAutoGain(bool& auto_gain /Out/) const;
+    void getAutoGain(bool& auto_gain /Out/);
 
     void setGain(double gain);
-    void getGain(double& gain /Out/) const;
+    void getGain(double& gain /Out/);
 
     void getStatus(Basler::Camera::Status& status /Out/);
 	
@@ -85,7 +85,7 @@ namespace Basler
     void hasVideoCapability(bool& video_flag /Out/) const;
     // -- change output line source
     void setOutput1LineSource(Basler::Camera::LineSource);
-    void getOutput1LineSource(Basler::Camera::LineSource&) const;
+    void getOutput1LineSource(Basler::Camera::LineSource&);
 
     // -- Pylon buffers statistics
     void getStatisticsTotalBufferCount(long& count);    

--- a/sip/BaslerInterface.sip
+++ b/sip/BaslerInterface.sip
@@ -32,7 +32,7 @@ namespace Basler
 %MethodCode
 	sipCpp->getCamera().setGain(a0);
 %End
-    void		getGain(double& gain /Out/) const;
+    void		getGain(double& gain /Out/);
 %MethodCode
 	sipCpp->getCamera().getGain(a0);
 %End
@@ -40,7 +40,7 @@ namespace Basler
 %MethodCode
 	sipCpp->getCamera().setAutoGain(a0);
 %End
-    void		getAutoGain(bool& auto_gain /Out/) const;
+    void		getAutoGain(bool& auto_gain /Out/);
 %MethodCode
 	sipCpp->getCamera().getAutoGain(a0);
 %End

--- a/src/BaslerSyncCtrlObj.cpp
+++ b/src/BaslerSyncCtrlObj.cpp
@@ -116,8 +116,11 @@ bool SyncCtrlObj::checkAutoExposureMode(HwSyncCtrlObj::AutoExposureMode mode) co
 {
   DEB_MEMBER_FUNCT();
   DEB_PARAM() << DEB_VAR1(mode);
+  Camera::Basler basler_cam = m_cam._getBasler();
+  Camera_t& camera = basler_cam.camera;
+
   bool checkFlag = mode == HwSyncCtrlObj::ON ?
-    GenApi::IsAvailable(m_cam.Camera_->ExposureAuto) : true;
+    GenApi::IsAvailable(camera.ExposureAuto) : true;
   DEB_RETURN() << DEB_VAR1(checkFlag);
   return checkFlag;
 }
@@ -126,12 +129,14 @@ void SyncCtrlObj::setHwAutoExposureMode(AutoExposureMode mode)
 {
   DEB_MEMBER_FUNCT();
   DEB_PARAM() << DEB_VAR1(mode);
+  Camera::Basler basler_cam = m_cam._getBasler();
+  Camera_t& camera = basler_cam.camera;
   try
     {
-       if ( GenApi::IsAvailable(m_cam.Camera_->ExposureAuto ))
+       if ( GenApi::IsAvailable(camera.ExposureAuto ))
        {
-            m_cam.Camera_->ExposureAuto.SetValue(mode == HwSyncCtrlObj::ON ?
-					   ExposureAuto_Continuous : ExposureAuto_Off);
+	   camera.ExposureAuto.SetValue(mode == HwSyncCtrlObj::ON ?
+					ExposureAuto_Continuous : ExposureAuto_Off);
        }
     }
   catch(GenICam::GenericException& e)

--- a/src/BaslerVideoCtrlObj.cpp
+++ b/src/BaslerVideoCtrlObj.cpp
@@ -64,7 +64,7 @@ void VideoCtrlObj::getSupportedVideoMode(std::list<VideoMode>& aList) const
   for(const _VideoMode* pt = BaslerVideoMode;pt->stringMode;++pt)
     {
       GenApi::IEnumEntry *anEntry = 
-	m_cam.Camera_->PixelFormat.GetEntryByName(pt->stringMode);
+	m_cam._getBasler().camera.PixelFormat.GetEntryByName(pt->stringMode);
       if(anEntry && GenApi::IsAvailable(anEntry))
 	aList.push_back(pt->mode);
     }
@@ -73,7 +73,7 @@ void VideoCtrlObj::getVideoMode(VideoMode &mode) const
 {
   DEB_MEMBER_FUNCT();
 
-  PixelFormatEnums aCurrentPixelFormat = m_cam.Camera_->PixelFormat.GetValue();
+  PixelFormatEnums aCurrentPixelFormat = m_cam._getBasler().camera.PixelFormat.GetValue();
   switch(aCurrentPixelFormat)
     {
     case PixelFormat_Mono8:             mode = Y8;		break;
@@ -103,6 +103,9 @@ void VideoCtrlObj::getVideoMode(VideoMode &mode) const
 void VideoCtrlObj::setVideoMode(VideoMode mode)
 {
   DEB_MEMBER_FUNCT();
+
+  Camera::Basler basler_cam = m_cam._getBasler();
+  Camera_t& camera = basler_cam.camera;
 
   std::list<PixelFormatEnums> pixelformat;
   switch(mode)
@@ -163,7 +166,7 @@ void VideoCtrlObj::setVideoMode(VideoMode mode)
     {
       try
 	{
-	  m_cam.Camera_->PixelFormat.SetValue(*i);
+	  camera.PixelFormat.SetValue(*i);
 	  succeed = true;
 	}
       catch (GenICam::GenericException &e)
@@ -209,16 +212,21 @@ void VideoCtrlObj::checkBin(Bin &bin)
 
 void VideoCtrlObj::checkRoi(const Roi&,Roi& hw_roi)
 {
+  Camera::Basler basler_cam = m_cam._getBasler();
+  Camera_t& camera = basler_cam.camera;
+
   hw_roi = Roi(0,0,
-	       m_cam.Camera_->Width.GetMax(),
-	       m_cam.Camera_->Height.GetMax());
+	       camera.Width.GetMax(),
+	       camera.Height.GetMax());
 }
 
 bool VideoCtrlObj::checkAutoGainMode(AutoGainMode mode) const
 {
+  Camera::Basler basler_cam = m_cam._getBasler();
+  Camera_t& camera = basler_cam.camera;
   return mode == OFF ? true :
-    GenApi::IsAvailable(m_cam.Camera_->GainAuto) && 
-    GenApi::IsAvailable(m_cam.Camera_->GainSelector);
+    GenApi::IsAvailable(camera.GainAuto) && 
+    GenApi::IsAvailable(camera.GainSelector);
 }
 
 void VideoCtrlObj::setHwAutoGainMode(AutoGainMode mode)


### PR DESCRIPTION
Add support for re-connecting camera:
- Lazy init: constructor doesn't throw exception; pylon device is
  initialized on first access
- `getDetectorModel/DetectorType` now access camera every time
  (in case camera is replaced)

Some `getXXX` methods cannot be const anymore because the camera might need initialization in case of first access or in case of a re-connection.

TODO: handle disconnection during acquisition (not tested)
