### PR TITLE
Add AcquisitionFrameRate feature

### DIFF
--- a/include/BaslerCamera.h
+++ b/include/BaslerCamera.h
@@ -186,12 +186,12 @@ class LIBBASLER_API Camera
     void getAcquisitionFrameCount(int& AFC) const;
 
     // -- change AcquisitionFrameRateEnable
-    void setAcquisitionFrameRateEnable(bool AFC);
-    void getAcquisitionFrameRateEnable(bool& AFC) const;
+    void setAcquisitionFrameRateEnable(bool AFRE);
+    void getAcquisitionFrameRateEnable(bool& AFRE) const;
 
     // -- change acq frame count
-    void setAcquisitionFrameRateAbs(int AFC);
-    void getAcquisitionFrameRateAbs(int& AFC) const;
+    void setAcquisitionFrameRateAbs(int AFRA);
+    void getAcquisitionFrameRateAbs(int& AFRA) const;
 
     // -- Pylon buffers statistics
     void getStatisticsTotalBufferCount(long& count);    

--- a/include/BaslerCamera.h
+++ b/include/BaslerCamera.h
@@ -185,6 +185,14 @@ class LIBBASLER_API Camera
     void setAcquisitionFrameCount(int AFC);
     void getAcquisitionFrameCount(int& AFC) const;
 
+    // -- change AcquisitionFrameRateEnable
+    void setAcquisitionFrameRateEnable(bool AFC);
+    void getAcquisitionFrameRateEnable(bool& AFC) const;
+
+    // -- change acq frame count
+    void setAcquisitionFrameRateAbs(int AFC);
+    void getAcquisitionFrameRateAbs(int& AFC) const;
+
     // -- Pylon buffers statistics
     void getStatisticsTotalBufferCount(long& count);    
     void getStatisticsFailedBufferCount(long& count);

--- a/sip/BaslerCamera.sip
+++ b/sip/BaslerCamera.sip
@@ -106,6 +106,14 @@ namespace Basler
     void setAcquisitionFrameCount(int AFC);
     void getAcquisitionFrameCount(int& AFC /Out/) const;
 
+    // -- change AcquisitionFrameRateEnable
+    void setAcquisitionFrameRateEnable(bool AFC);
+    void getAcquisitionFrameRateEnable(bool& AFC) const;
+
+    // -- change acq frame count
+    void setAcquisitionFrameRateAbs(int AFC);
+    void getAcquisitionFrameRateAbs(int& AFC) const;
+
     // -- Pylon buffers statistics
     void getStatisticsTotalBufferCount(long& count);    
     void getStatisticsFailedBufferCount(long& count);

--- a/src/BaslerCamera.cpp
+++ b/src/BaslerCamera.cpp
@@ -1800,6 +1800,96 @@ void Camera::setFrameTransmissionDelay(int ftd)
     }
 }
 
+//--------------------------------------------------------
+//
+//-----------------------------------------------------
+void Camera::setAcquisitionFrameRateEnable(bool& val)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_PARAM() << DEB_VAR1(val);
+    try
+    {
+        Camera_->AcquisitionFrameRateEnable.SetValue(val);
+    }
+    catch (GenICam::GenericException &e)
+    {
+        // Error handling
+        THROW_HW_ERROR(Error) << e.GetDescription();
+    }
+}
+
+//--------------------------------------------------------
+//
+//-----------------------------------------------------
+void Camera::getAcquisitionFrameRateEnable(bool& val) const
+{
+    DEB_MEMBER_FUNCT();
+    DEB_PARAM() << DEB_VAR1(val);
+    try
+    {
+        if (GenApi::IsAvailable(Camera_->AcquisitionFrameRateEnable))
+        {
+        val  = Camera_->AcquisitionFrameRateEnable.GetValue();
+        }
+        else
+        {
+            val = false;
+//			THROW_HW_ERROR(Error)<<"AcquisitionFrameRateEnable Parameter is not Available !";
+        }
+    }
+    catch (GenICam::GenericException &e)
+    {
+        // Error handling
+        THROW_HW_ERROR(Error) << e.GetDescription();
+    }
+        DEB_RETURN() << DEB_VAR1(val);
+
+}
+//--------------------------------------------------------
+//
+//-----------------------------------------------------
+void Camera::setAcquisitionFrameRateAbs(int& val)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_PARAM() << DEB_VAR1(val);
+    try
+    {
+        Camera_->AcquisitionFrameRateAbs.SetValue(val);
+    }
+    catch (GenICam::GenericException &e)
+    {
+        // Error handling
+        THROW_HW_ERROR(Error) << e.GetDescription();
+    }
+}
+
+//--------------------------------------------------------
+//
+//-----------------------------------------------------
+void Camera::getAcquisitionFrameRateAbs(int& val)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_PARAM() << DEB_VAR1(val);
+    try
+    {
+        if (GenApi::IsAvailable(Camera_->AcquisitionFrameRateAbs))
+        {
+        val  = Camera_->AcquisitionFrameRateAbs.GetValue();
+        }
+        else
+        {
+            val = false;
+//			THROW_HW_ERROR(Error)<<"AcquisitionFrameRateAbs Parameter is not Available !";
+        }
+    }
+    catch (GenICam::GenericException &e)
+    {
+        // Error handling
+        THROW_HW_ERROR(Error) << e.GetDescription();
+    }
+        DEB_RETURN() << DEB_VAR1(val);
+
+}
 //---------------------------
 //- Camera::reset()
 //---------------------------

--- a/src/BaslerCamera.cpp
+++ b/src/BaslerCamera.cpp
@@ -1803,13 +1803,13 @@ void Camera::setFrameTransmissionDelay(int ftd)
 //--------------------------------------------------------
 //
 //-----------------------------------------------------
-void Camera::setAcquisitionFrameRateEnable(bool& val)
+void Camera::setAcquisitionFrameRateEnable(bool AFRE)
 {
     DEB_MEMBER_FUNCT();
-    DEB_PARAM() << DEB_VAR1(val);
+    DEB_PARAM() << DEB_VAR1(AFRE);
     try
     {
-        Camera_->AcquisitionFrameRateEnable.SetValue(val);
+        Camera_->AcquisitionFrameRateEnable.SetValue(AFRE);
     }
     catch (GenICam::GenericException &e)
     {
@@ -1821,19 +1821,19 @@ void Camera::setAcquisitionFrameRateEnable(bool& val)
 //--------------------------------------------------------
 //
 //-----------------------------------------------------
-void Camera::getAcquisitionFrameRateEnable(bool& val) const
+void Camera::getAcquisitionFrameRateEnable(bool& AFRE) const
 {
     DEB_MEMBER_FUNCT();
-    DEB_PARAM() << DEB_VAR1(val);
+    DEB_PARAM() << DEB_VAR1(AFRE);
     try
     {
         if (GenApi::IsAvailable(Camera_->AcquisitionFrameRateEnable))
         {
-        val  = Camera_->AcquisitionFrameRateEnable.GetValue();
+            AFRE  = Camera_->AcquisitionFrameRateEnable.GetValue();
         }
         else
         {
-            val = false;
+            AFRE = false;
 //			THROW_HW_ERROR(Error)<<"AcquisitionFrameRateEnable Parameter is not Available !";
         }
     }
@@ -1842,19 +1842,19 @@ void Camera::getAcquisitionFrameRateEnable(bool& val) const
         // Error handling
         THROW_HW_ERROR(Error) << e.GetDescription();
     }
-        DEB_RETURN() << DEB_VAR1(val);
+        DEB_RETURN() << DEB_VAR1(AFRE);
 
 }
 //--------------------------------------------------------
 //
 //-----------------------------------------------------
-void Camera::setAcquisitionFrameRateAbs(int& val)
+void Camera::setAcquisitionFrameRateAbs(int AFRA)
 {
     DEB_MEMBER_FUNCT();
-    DEB_PARAM() << DEB_VAR1(val);
+    DEB_PARAM() << DEB_VAR1(AFRA);
     try
     {
-        Camera_->AcquisitionFrameRateAbs.SetValue(val);
+        Camera_->AcquisitionFrameRateAbs.SetValue(AFRA);
     }
     catch (GenICam::GenericException &e)
     {
@@ -1866,19 +1866,19 @@ void Camera::setAcquisitionFrameRateAbs(int& val)
 //--------------------------------------------------------
 //
 //-----------------------------------------------------
-void Camera::getAcquisitionFrameRateAbs(int& val)
+void Camera::getAcquisitionFrameRateAbs(int& AFRA) const
 {
     DEB_MEMBER_FUNCT();
-    DEB_PARAM() << DEB_VAR1(val);
+    DEB_PARAM() << DEB_VAR1(AFRA);
     try
     {
         if (GenApi::IsAvailable(Camera_->AcquisitionFrameRateAbs))
         {
-        val  = Camera_->AcquisitionFrameRateAbs.GetValue();
+        AFRA  = Camera_->AcquisitionFrameRateAbs.GetValue();
         }
         else
         {
-            val = false;
+            AFRA = false;
 //			THROW_HW_ERROR(Error)<<"AcquisitionFrameRateAbs Parameter is not Available !";
         }
     }
@@ -1887,7 +1887,7 @@ void Camera::getAcquisitionFrameRateAbs(int& val)
         // Error handling
         THROW_HW_ERROR(Error) << e.GetDescription();
     }
-        DEB_RETURN() << DEB_VAR1(val);
+        DEB_RETURN() << DEB_VAR1(AFRA);
 
 }
 //---------------------------


### PR DESCRIPTION
Accidentally I deleted [#23](https://github.com/esrf-bliss/Lima-camera-basler/pull/23) Pull Request.
This PR has the same feature.
Add AcquisitionFrameRate features like AcquisitionFrameRateEnable and AcquisitionFrameRateAbs.AcquisitionFrameRateEnable allows to enable/disable the max frame rate between the camera and lima, it limits the events generated by Basler Camera.AcquisitionFrameRateAbs allows to set the max frame rate for the basler camera.



