### PR TITLE
upgrades 10bpp cameras to using 2-bytes instead of only 1

### DIFF
--- a/src/BaslerCamera.cpp
+++ b/src/BaslerCamera.cpp
@@ -237,6 +237,7 @@ Camera::Camera(const std::string& camera_id,int packet_size,int receive_priority
 	  {
 	    formatList.push_back(string("Mono16"));
 	    formatList.push_back(string("Mono12"));
+	    formatList.push_back(string("Mono10"));
 	    formatList.push_back(string("Mono8"));
 	    m_color_flag = false;
 	  }
@@ -595,7 +596,7 @@ void Camera::getImageType(ImageType& type)
       case PixelFormat_Mono10:
       case PixelFormat_BayerRG10:
       case PixelFormat_BayerBG10:
-	type = Bpp10;
+	type= Bpp10;
 	break;
 	
       case PixelFormat_Mono12:
@@ -628,6 +629,9 @@ void Camera::setImageType(ImageType type)
         {
             case Bpp8:
                 this->Camera_->PixelFormat.SetValue(PixelFormat_Mono8);
+                break;
+            case Bpp10:
+                this->Camera_->PixelFormat.SetValue(PixelFormat_Mono10);
                 break;
             case Bpp12:
                 this->Camera_->PixelFormat.SetValue(PixelFormat_Mono12);

--- a/src/BaslerVideoCtrlObj.cpp
+++ b/src/BaslerVideoCtrlObj.cpp
@@ -63,6 +63,7 @@ void VideoCtrlObj::getSupportedVideoMode(std::list<VideoMode>& aList) const
       {"YUV444Packed",YUV444PACKED},
       {"Mono16",Y16},
       {"Mono12",Y16},
+      {"Mono10",Y16},
       {"Mono8",Y8},
       {NULL,Y8}
     };


### PR DESCRIPTION
I have a 10bpp mono camera (acA2500-20gm) and this plugin was using only 8bpp, and the beamline scientists were complaining that it was saturating too fast. This fixes it.
The changes are very localized. I also tested this against a different camera (acA1300-30gm, 12bits mono) to make sure it didn't introduce any side-effects to other cameras.